### PR TITLE
Fix video links

### DIFF
--- a/01_program_philosophy.Rmd
+++ b/01_program_philosophy.Rmd
@@ -35,6 +35,6 @@ We do recognize that internet access is also a limiting factor for many people. 
 
 ### Slides and Video
 
-![Program Philosophy](https://youtu.be/7yZBE_FAeYY)
+[Automated Video](https://youtu.be/7yZBE_FAeYY)
 
 * [Slides](https://docs.google.com/presentation/d/1s7sLqa0GAUqVaD9TE63ntBKJfXm2Ac2dG90G_41egLI/edit?usp=sharing)

--- a/02_why_automated.Rmd
+++ b/02_why_automated.Rmd
@@ -46,6 +46,6 @@ If you find the robot voice annoying, we get it. We know that the technology isn
 
 ### Slides and Video
 
-![Why Automated Videos](https://youtu.be/OZZt6ycsAxw)
+[Automated Video](https://youtu.be/OZZt6ycsAxw)
 
 * [Slides](https://docs.google.com/presentation/d/1FtdynwBR8IAE8x9cMTZrnWKfTPXEhH-KwkAZKQ0zwk8/edit?usp=sharing)

--- a/03_data_science_process.Rmd
+++ b/03_data_science_process.Rmd
@@ -95,6 +95,6 @@ In this lesson, we hope we've conveyed that sometimes data science projects are 
 
 ### Slides and Video
 
-![The Data Science Process](https://youtu.be/UQ1f8O-PqXw)
+[Automated Video](https://youtu.be/UQ1f8O-PqXw)
 
 * [Slides](https://docs.google.com/presentation/d/1SNT3SYuWJhjRYx7VmyFKWkuxESEx5THt-mWJ7Mx5Cr8/edit?usp=sharing)

--- a/04_how_to_learn.Rmd
+++ b/04_how_to_learn.Rmd
@@ -69,6 +69,6 @@ Learning how to learn and asking questions may seem simple when you read this le
 
 ### Slides and Video
 
-![How To Learn](https://youtu.be/6FVNLlM7Hv8)
+[Automated Video](https://youtu.be/6FVNLlM7Hv8)
 
 * [Slides](https://docs.google.com/presentation/d/1sgE2Um0t2AhkUlPHLJDSVLTJlyTabg1gtz1ybOgO-kY/edit?usp=sharing)

--- a/05_finding_help.Rmd
+++ b/05_finding_help.Rmd
@@ -45,6 +45,6 @@ The best way to get a response to your question is to be able to boil it down to
 
 
 
-![Finding Help](https://youtu.be/k6O8wwpW49U)
+[Automated Video](https://youtu.be/k6O8wwpW49U)
 
 * [Slides](https://docs.google.com/presentation/d/180OSJkB2c7BxvtJZ3F-KrGzQ33vPLWbErC2xjO6g4O4/edit?usp=sharing)

--- a/06_account_setup.Rmd
+++ b/06_account_setup.Rmd
@@ -36,6 +36,6 @@ To give you an idea of where we're going, the first account (and arguably the mo
 
 ### Slides and Video
 
-![Account Setup](https://youtu.be/CzJzjBPSyFw)
+[Automated Video](https://youtu.be/CzJzjBPSyFw)
 
 * [Slides](https://docs.google.com/presentation/d/1mQMEdR4opFzuReP9i7te5v8T-kyDNNklHPvQ2OnzZpQ/edit?usp=sharing)

--- a/07_google_account_.Rmd
+++ b/07_google_account_.Rmd
@@ -68,6 +68,6 @@ Enter your new Google account name here. Click 'Next'. Enter your password. Clic
 
 ### Slides and Video
 
-![Google Account Setup](https://youtu.be/strPcZCzGSs)
+[Automated Video](https://youtu.be/strPcZCzGSs)
 
 * [Slides](https://docs.google.com/presentation/d/1sOBtwszQqq366q84VCDY_BwSjWQz_4yFJLC4ib1dEGQ/edit?usp=sharing)

--- a/08_other_accounts_setup.Rmd
+++ b/08_other_accounts_setup.Rmd
@@ -152,6 +152,6 @@ You now have a GitHub account *and* all of the online accounts needed for this p
 
 ### Slides and Video
 
-![Other Accounts Setup](https://youtu.be/wdtAxwtY0QQ)
+[Automated Video](https://youtu.be/wdtAxwtY0QQ)
 
 * [Slides](https://docs.google.com/presentation/d/1NbqkwyE9f4__0uTHWiVDoZaVfb_sMqJw4LTNcvsVw3A/edit?usp=sharing)

--- a/09_your_first_data_science_project.Rmd
+++ b/09_your_first_data_science_project.Rmd
@@ -54,6 +54,6 @@ We'll go through the steps necessary to do all of this and answer the project qu
 
 ### Slides and Video
 
-![Your First Data Science Project](https://youtu.be/bnwV4TdQ9_Q)
+[Automated Video](https://youtu.be/bnwV4TdQ9_Q)
 
 [Slides](https://docs.google.com/presentation/d/1auByZV5pghzELH-SMKLwxrZtigtXd-PC4Q5SrcT4qlE/edit?usp=sharing)

--- a/10_google_sheets.Rmd
+++ b/10_google_sheets.Rmd
@@ -134,6 +134,6 @@ Congrats!! You have successfully made this spreadsheet shareable and the link ha
 
 ### Slides and Video
 
-![Google Sheets](https://youtu.be/-Mh2AbCisQA)
+[Automated Video](https://youtu.be/-Mh2AbCisQA)
 
 * [Slides](https://docs.google.com/presentation/d/1EPt7DuMZOqJMElDNMi3PWO66OytMlWPoc-RsopdVxNM/edit?usp=sharing)

--- a/11_rstudio_cloud.Rmd
+++ b/11_rstudio_cloud.Rmd
@@ -135,6 +135,6 @@ Once you have your plot, you have what you need to make the Google Doc and finis
 
 ### Slides and Video
 
-![RStudio Cloud](https://youtu.be/O0QeE37cs3Y)
+[Automated Video](https://youtu.be/O0QeE37cs3Y)
 
 * [Slides](https://docs.google.com/presentation/d/1FFaIAQO7qtUANdHApu4fFCcB0KT9FNo5oQCWLULqsdY/edit?usp=sharing)

--- a/12_google_docs.Rmd
+++ b/12_google_docs.Rmd
@@ -81,6 +81,6 @@ A new screen will pop up informing you that your link has been copied. This is t
 
 ### Slides and Video
 
-![Google Docs](https://youtu.be/p-594SFMNa4)
+[Automated Video](https://youtu.be/p-594SFMNa4)
 
 * [Slides](https://docs.google.com/presentation/d/13arBfuP1WFhTca0XCZNMBB7G1gxn8ZCJhpxsqdpDz_A/edit?usp=sharing)

--- a/13_googleslides.Rmd
+++ b/13_googleslides.Rmd
@@ -95,6 +95,6 @@ This will bring up a new box indicating that your link has been copied. This is 
 
 ### Slides and Video
 
-![Google Slides](https://youtu.be/nRFevt8u_yo)
+[Automated Video](https://youtu.be/nRFevt8u_yo)
 
 * [Slides](https://docs.google.com/presentation/d/1sjOuMmP1oXuqvTMeKlAoOSCqD-TOncWraD67b_pzrUE/edit?usp=sharing)


### PR DESCRIPTION
For some reason the video links have `![]` and don't work and instead need to just be `[]`

I did a find all and replace all for all the youtube links. But unfortunately this means I had to put a universal link title. I think it should be okay though. 